### PR TITLE
add project variable NETWORK_THEME

### DIFF
--- a/annex-1/mappings/AirTransportNetwork/aaa-tn-a-01.halex
+++ b/annex-1/mappings/AirTransportNetwork/aaa-tn-a-01.halex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="3.2.0.qualifier">
+<hale-project version="3.5.0.SNAPSHOT">
     <name>3A zu INSPIRE Air Transport Network</name>
     <author>Simon Templer</author>
     <description>### Alignment von 3A zum INSPIRE Air Transport Network GML Anwendungsschema.
@@ -23,17 +23,17 @@ Im Projekt gibt es zwei verschiedene Herangehensweisen zur Bildung von *Transpor
 1. Ein *TransportProperty*-Objekt für alle Features die auf die gleichen Werte abgebildet werden. Die Identifier werden dabei basierend auf dem Wert oder den Werten welche die jeweilige *TransportProperty* ausmachen gebildet. Umgesetzt wurde das so für `ConditionOfAirFacility`, `SurfaceComposition`, `AerodromeCategory`, `AerodromeType`, und `UseRestriction`.
 2. Ein *TransportProperty*-Objekt für jedes (Quell-)Feature dass über entsprechende Eigenschaften verfügt. Dabei gibt es ggf. sehr viele redundante Informationen in den Objekten. Umgesetzt wurde das so für `ElementWidth`.</description>
     <created>2015-09-28T11:46:45.435+02:00</created>
-    <modified>2017-01-31T14:29:08.393+01:00</modified>
+    <modified>2018-10-12T10:01:58.312+02:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.project.hale25.xml</setting>
-        <setting name="target">file:/home/simon/repos/inspire-alignements/annex-1/mappings/AirTransportNetwork/aaa-tn-a-01.halex</setting>
+        <setting name="target">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/annex-1/mappings/AirTransportNetwork/aaa-tn-a-01.halex</setting>
     </save-config>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.source" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
         <setting name="charset">UTF-8</setting>
         <setting name="resourceId">fe9e4898-e2ab-4559-bec6-c92a9e455eef</setting>
-        <setting name="source">file:/home/simon/repos/inspire-alignements/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
+        <setting name="source">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.xsd</setting>
     </resource>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.target" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
@@ -46,7 +46,7 @@ Im Projekt gibt es zwei verschiedene Herangehensweisen zur Bildung von *Transpor
     <resource action-id="eu.esdihumboldt.hale.io.instance.read.source" provider-id="eu.esdihumboldt.hale.io.xml.reader">
         <setting name="charset">UTF-8</setting>
         <setting name="resourceId">6a2f5f63-3eb0-445f-9687-08220f2a3e27</setting>
-        <setting name="source">file:/home/simon/repos/inspire-alignements/testdaten/Hamburg/ATKIS/ATKIS_HH_0011.xml.gz</setting>
+        <setting name="source">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/testdaten/Hamburg/ATKIS/ATKIS_HH_0011.xml.gz</setting>
         <setting name="strict">false</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.xml.gzip</setting>
         <setting name="ignoreNamespaces">false</setting>
@@ -1726,6 +1726,9 @@ Im Projekt gibt es zwei verschiedene Herangehensweisen zur Bildung von *Transpor
         <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
             <core:property name="NETWORK_ID">
                 <core:value value="AirTransportNetwork"/>
+            </core:property>
+            <core:property name="NETWORK_THEME">
+                <core:value value=""/>
             </core:property>
             <core:property name="INSPIRE_NAMESPACE">
                 <core:value value="https://registry.gdi-de.org/id/de.____"/>

--- a/annex-1/mappings/CableTransportNetwork/aaa-tn-c-01.halex
+++ b/annex-1/mappings/CableTransportNetwork/aaa-tn-c-01.halex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="3.1.0.qualifier">
+<hale-project version="3.5.0.SNAPSHOT">
     <name>3A zu INSPIRE Cable Transport Network</name>
     <author>Simon Templer</author>
     <description>### Alignment von 3A zum INSPIRE Cable Transport Network GML Anwendungsschema.
@@ -12,17 +12,17 @@
 - Bei der Abbildung `AX_SeilbahnSchwebebahn` nach `CablewayLink` werden Objekte anhand ihrer (Mehrfach-)Geometrie in mehrere Ziel-Objekte aufgeteilt werden. Hier wurde die ID des Zielobjekts jeweils mit der entsprechenden Nummer der Geometrie (1., 2., etc. Geometrie) als Suffix angehängt.
 </description>
     <created>2015-09-28T11:46:45.435+02:00</created>
-    <modified>2016-11-28T13:44:39.980+01:00</modified>
+    <modified>2018-10-12T12:09:21.430+02:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.project.hale25.xml</setting>
-        <setting name="target">file:/home/simon/repos/inspire-alignements/annex-1/mappings/CableTransportNetwork/aaa-tn-c-01.halex</setting>
+        <setting name="target">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/annex-1/mappings/CableTransportNetwork/aaa-tn-c-01.halex</setting>
     </save-config>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.source" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
         <setting name="charset">UTF-8</setting>
         <setting name="resourceId">fe9e4898-e2ab-4559-bec6-c92a9e455eef</setting>
-        <setting name="source">file:/home/simon/repos/inspire-alignements/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
+        <setting name="source">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.xsd</setting>
     </resource>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.target" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
@@ -41,7 +41,7 @@
     <resource action-id="eu.esdihumboldt.hale.io.instance.read.source" provider-id="eu.esdihumboldt.hale.io.xml.reader">
         <setting name="charset">UTF-8</setting>
         <setting name="resourceId">50c2f159-d569-43e8-970b-15d7ee098550</setting>
-        <setting name="source">file:/home/simon/repos/inspire-alignements/testdaten/Bayern/601_DLM25_7937_n.xml.gz</setting>
+        <setting name="source">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/testdaten/Bayern/601_DLM25_7937_n.xml.gz</setting>
         <setting name="strict">false</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.xml.gzip</setting>
         <setting name="ignoreNamespaces">false</setting>
@@ -1578,6 +1578,9 @@
         <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
             <core:property name="NETWORK_ID">
                 <core:value value="CableTransportNetwork"/>
+            </core:property>
+            <core:property name="NETWORK_THEME">
+                <core:value value=""/>
             </core:property>
             <core:property name="INSPIRE_NAMESPACE">
                 <core:value value="https://registry.gdi-de.org/id/de.____"/>

--- a/annex-1/mappings/RailroadTransportNetwork/aaa-tn-ra-01.halex
+++ b/annex-1/mappings/RailroadTransportNetwork/aaa-tn-ra-01.halex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="3.2.0.qualifier">
+<hale-project version="3.5.0.SNAPSHOT">
     <name>3A zu INSPIRE Railway Transport Network</name>
     <author>Simon Templer</author>
     <description>### Alignment von 3A zum INSPIRE Railway Transport Network GML Anwendungsschema.
@@ -21,17 +21,17 @@ Dieses Verhalten ließe sich auch mit wenigen Änderungen anpassen, so dass für
 
 Im Alignment wird ein *TransportProperty*-Objekt erstellt zusammenfassend für alle Features die auf die gleichen Werte abgebildet werden (z.B. gleicher Zustand für `ConditionOfFacility`). Die Identifier werden dabei basierend auf dem Wert oder den Werten welche die jeweilige *TransportProperty* ausmachen gebildet.</description>
     <created>2015-09-28T11:46:45.435+02:00</created>
-    <modified>2017-01-31T14:08:07.672+01:00</modified>
+    <modified>2018-10-12T11:52:30.572+02:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.project.hale25.xml</setting>
-        <setting name="target">file:/home/simon/repos/inspire-alignements/annex-1/mappings/RailroadTransportNetwork/aaa-tn-ra-01.halex</setting>
+        <setting name="target">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/annex-1/mappings/RailroadTransportNetwork/aaa-tn-ra-01.halex</setting>
     </save-config>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.source" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
         <setting name="charset">UTF-8</setting>
         <setting name="resourceId">fe9e4898-e2ab-4559-bec6-c92a9e455eef</setting>
-        <setting name="source">file:/home/simon/repos/inspire-alignements/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
+        <setting name="source">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.xsd</setting>
     </resource>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.target" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
@@ -1537,6 +1537,9 @@ Im Alignment wird ein *TransportProperty*-Objekt erstellt zusammenfassend für a
         <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
             <core:property name="NETWORK_ID">
                 <core:value value="RailwayNetwork"/>
+            </core:property>
+            <core:property name="NETWORK_THEME">
+                <core:value value=""/>
             </core:property>
             <core:property name="INSPIRE_NAMESPACE">
                 <core:value value="https://registry.gdi-de.org/id/de.____"/>

--- a/annex-1/mappings/RoadTransportNetwork/aaa-tn-ro-01.halex
+++ b/annex-1/mappings/RoadTransportNetwork/aaa-tn-ro-01.halex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="3.2.0.release">
+<hale-project version="3.5.0.SNAPSHOT">
     <name>3A zu INSPIRE Road Transport Network</name>
     <author>Simon Templer</author>
     <description>### Alignment von 3A zum INSPIRE Road Transport Network GML Anwendungsschema.
@@ -22,18 +22,18 @@ Im Projekt gibt es drei verschiedene Herangehensweisen zur Bildung von *Transpor
 1. Ein *TransportProperty*-Objekt für alle Features die auf die gleichen Werte abgebildet werden. Die Identifier werden dabei basierend auf dem Wert oder den Werten welche die jeweilige *TransportProperty* ausmachen gebildet. Umgesetzt wurde das so für `ConditionOfFacility`, `FormOfWay`, `FunctionalRoadClass`, `NumberOfLanes`, und `RoadSurfaceCategory`.
 2. Ein *TransportProperty*-Objekt für alle Features die in den Quell-Daten die gleichen relevanten Informationen aufweisen. Die Identifier werden dabei basierend auf dem Quell-Wert oder -Werten gebildet. Umgesetzt wurde das so für `RoadServiceType`.
 3. Ein *TransportProperty*-Objekt für jedes Feature dass über entsprechende Eigenschaften verfügt. Dabei gibt es ggf. sehr viele redundante Informationen in den Objekten. Umgesetzt wurde das so für `RoadWidth`.</description>
-    <created>2015-09-28T09:46:45.435Z</created>
-    <modified>2017-05-22T08:30:25.658Z</modified>
+    <created>2015-09-28T11:46:45.435+02:00</created>
+    <modified>2018-10-12T12:02:56.064+02:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.project.hale25.xml</setting>
-        <setting name="target">file:/home/simon/repos/inspire-alignements/annex-1/mappings/RoadTransportNetwork/aaa-tn-ro-01.halex</setting>
+        <setting name="target">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/annex-1/mappings/RoadTransportNetwork/aaa-tn-ro-01.halex</setting>
     </save-config>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.source" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
         <setting name="charset">UTF-8</setting>
         <setting name="resourceId">fe9e4898-e2ab-4559-bec6-c92a9e455eef</setting>
-        <setting name="source">file:/home/simon/repos/inspire-alignements/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
+        <setting name="source">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.xsd</setting>
     </resource>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.target" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
@@ -1701,6 +1701,9 @@ Im Projekt gibt es drei verschiedene Herangehensweisen zur Bildung von *Transpor
         <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
             <core:property name="NETWORK_ID">
                 <core:value value="RoadNetwork"/>
+            </core:property>
+            <core:property name="NETWORK_THEME">
+                <core:value value=""/>
             </core:property>
             <core:property name="INSPIRE_NAMESPACE">
                 <core:value value="https://registry.gdi-de.org/id/de.____"/>

--- a/annex-1/mappings/WaterTransportNetwork/aaa-tn-w-01.halex
+++ b/annex-1/mappings/WaterTransportNetwork/aaa-tn-w-01.halex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="3.2.0.release">
+<hale-project version="3.5.0.SNAPSHOT">
     <name>3A zu INSPIRE Water Transport Network</name>
     <author>Simon Templer</author>
     <description>### Alignment von 3A zum INSPIRE Water Transport Network GML Anwendungsschema.
@@ -21,17 +21,17 @@ Dieses Verhalten ließe sich auch mit wenigen Änderungen anpassen, so dass für
 Ein *TransportProperty*-Objekt wird erstellt für alle Features die über die gleichen Eigenschaften bzgl. der *TransportProperty* verfügen. Die Identifier werden dabei basierend auf dem Wert oder den Werten welche die jeweilige *TransportProperty* ausmachen gebildet. Umgesetzt wurde das so für `ConditionOfWaterFacility`, `FerryUse` und `VerticalPosition`.
 </description>
     <created>2015-09-28T11:46:45.435+02:00</created>
-    <modified>2017-03-08T16:34:03.872+01:00</modified>
+    <modified>2018-10-12T12:12:04.660+02:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.project.hale25.xml</setting>
-        <setting name="target">file:/home/simon/repos/inspire-alignements/annex-1/mappings/WaterTransportNetwork/aaa-tn-w-01.halex</setting>
+        <setting name="target">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/annex-1/mappings/WaterTransportNetwork/aaa-tn-w-01.halex</setting>
     </save-config>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.source" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
         <setting name="charset">UTF-8</setting>
         <setting name="resourceId">fe9e4898-e2ab-4559-bec6-c92a9e455eef</setting>
-        <setting name="source">file:/home/simon/repos/inspire-alignements/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
+        <setting name="source">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.xsd</setting>
     </resource>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.target" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
@@ -44,7 +44,7 @@ Ein *TransportProperty*-Objekt wird erstellt für alle Features die über die gl
     <resource action-id="eu.esdihumboldt.hale.io.instance.read.source" provider-id="eu.esdihumboldt.hale.io.xml.reader">
         <setting name="charset">UTF-8</setting>
         <setting name="resourceId">10618f26-dc80-4c44-b988-ee8cbfbd0878</setting>
-        <setting name="source">file:/home/simon/repos/inspire-alignements/testdaten/Hamburg/ATKIS/ATKIS_HH_0006.xml.gz</setting>
+        <setting name="source">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/testdaten/Hamburg/ATKIS/ATKIS_HH_0006.xml.gz</setting>
         <setting name="strict">false</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.xml.gzip</setting>
         <setting name="ignoreNamespaces">false</setting>
@@ -53,7 +53,7 @@ Ein *TransportProperty*-Objekt wird erstellt für alle Features die über die gl
     <resource action-id="eu.esdihumboldt.hale.io.instance.read.source" provider-id="eu.esdihumboldt.hale.io.xml.reader">
         <setting name="charset">UTF-8</setting>
         <setting name="resourceId">24987c01-1d07-4160-b909-deb02038c96e</setting>
-        <setting name="source">file:/home/simon/repos/inspire-alignements/testdaten/Hamburg/ATKIS/ATKIS_HH_0007.xml.gz</setting>
+        <setting name="source">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/testdaten/Hamburg/ATKIS/ATKIS_HH_0007.xml.gz</setting>
         <setting name="strict">false</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.xml.gzip</setting>
         <setting name="ignoreNamespaces">false</setting>
@@ -1403,6 +1403,9 @@ Ein *TransportProperty*-Objekt wird erstellt für alle Features die über die gl
         <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
             <core:property name="NETWORK_ID">
                 <core:value value="WaterTransportNetwork"/>
+            </core:property>
+            <core:property name="NETWORK_THEME">
+                <core:value value=""/>
             </core:property>
             <core:property name="INSPIRE_NAMESPACE">
                 <core:value value="https://registry.gdi-de.org/id/de.____"/>

--- a/annex-1/mappings/base-tn.halex
+++ b/annex-1/mappings/base-tn.halex
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="3.1.0.qualifier">
+<hale-project version="3.5.0.SNAPSHOT">
     <name>Basisprojekt INSPIRE Transport Networks</name>
     <author>Simon Templer</author>
     <description>Basisprojekt für gemeinsame Funktionalität für INSPIRE Transport Networks Projekte.</description>
     <created>2015-09-28T11:46:45.435+02:00</created>
-    <modified>2016-11-28T13:53:05.159+01:00</modified>
+    <modified>2018-10-12T09:48:22.920+02:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.project.hale25.xml</setting>
-        <setting name="target">file:/home/simon/repos/inspire-alignements/annex-1/mappings/base-tn.halex</setting>
+        <setting name="target">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/annex-1/mappings/base-tn.halex</setting>
     </save-config>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.source" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
         <setting name="charset">UTF-8</setting>
         <setting name="resourceId">fe9e4898-e2ab-4559-bec6-c92a9e455eef</setting>
-        <setting name="source">file:/home/simon/repos/inspire-alignements/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
+        <setting name="source">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.xsd</setting>
     </resource>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.target" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
@@ -1275,6 +1275,9 @@
         <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
             <core:property name="NETWORK_ID">
                 <core:value value="TransportNetwork"/>
+            </core:property>
+            <core:property name="NETWORK_THEME">
+                <core:value value=""/>
             </core:property>
             <core:property name="NETWORK_NAME">
                 <core:value value="Network"/>

--- a/annex-1/mappings/base-tn.halex.alignment.xml
+++ b/annex-1/mappings/base-tn.halex.alignment.xml
@@ -76,7 +76,7 @@ withTransformationContext {
 // Inhalt der hier gesetzt wird sind die Identifier und die Verknüpfungen
 // zu den entsprechenden Netzwerk-Elementen
 collect.conditionOfFacility.consume { key, values -&gt;
-	def _id = 'ConditionOfFacility_' + key
+	def _id = 'ConditionOfFacility_' + _project.vars.NETWORK_THEME + '_' + key
 	def _ns = _project.vars.INSPIRE_NAMESPACE
 	
 	_target {
@@ -380,7 +380,7 @@ withTransformationContext {
 // Inhalt der hier gesetzt wird sind die Identifier und die Verknüpfungen
 // zu den entsprechenden Netzwerk-Elementen
 collect.verticalPosition.consume { key, values -&gt;
-	def _id = 'VerticalPosition_' + key
+	def _id = 'VerticalPosition_' + _project.vars.NETWORK_THEME + '_' + key
 	def _ns = _project.vars.INSPIRE_NAMESPACE
 	
 	_target {


### PR DESCRIPTION
to be able to distinguish between transport properties from the common
transport elements schema if they are used for more than one network
theme. The value of the variable can be empty if the target datasets are
stored separately. It should be Air, Cable, Railway, Road or Water if
the distinction is needed.