### PR TITLE
Fix lowerLevelUnit generation for Verwaltungsgemeinschaften 

### DIFF
--- a/annex-1/mappings6.0/AdministrativeUnits/aaa-au-flurstuecke.halex
+++ b/annex-1/mappings6.0/AdministrativeUnits/aaa-au-flurstuecke.halex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="3.4.0.release">
+<hale-project version="4.1.0.SNAPSHOT">
     <name>[Annex I] AdV 3A zu INSPIRE Administrative Units (Variante Flurstücke)</name>
     <author>Simon Templer</author>
     <description>Alignment vom 3A-Modell zum INSPIRE Anwendungsschema Administrative Units.
@@ -15,7 +15,7 @@ Das gleiche gilt für die aggregierten Geometrien -- hier werden bei unvollstän
 
 Sofern möglich sollte alternativ für die Transformation das Projekt mit Aggregierung aus `AX_KommunalesGebiet` verwendet werden. Falls diese Objekte nich vorhanden sind, könnten als Zwischenschritt auch `AX_KommunalesGebiet` aus Flurstücken abgeleitet werden.</description>
     <created>2015-09-28T11:46:45.435+02:00</created>
-    <modified>2018-11-02T17:26:57.154+01:00</modified>
+    <modified>2021-08-25T10:49:36.470+02:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>

--- a/annex-1/mappings6.0/AdministrativeUnits/aaa-au-flurstuecke.halex.alignment.xml
+++ b/annex-1/mappings6.0/AdministrativeUnits/aaa-au-flurstuecke.halex.alignment.xml
@@ -532,9 +532,9 @@ _target{
 		MultiSurface( union )
 	}
 	// Verweis auf Gemeinden
-	gemeinden.each {
+	gemeinden.each { gem -&gt;
 		lowerLevelUnit {
-			href( "#AdministrativeUnit_$it" )
+			href( "#AdministrativeUnit_$gem" )
 		}
 	}
 	_b.upperLevelUnit {

--- a/annex-1/mappings6.0/AdministrativeUnits/aaa-au-gebiete.halex
+++ b/annex-1/mappings6.0/AdministrativeUnits/aaa-au-gebiete.halex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="3.4.0.release">
+<hale-project version="4.1.0.SNAPSHOT">
     <name>[Annex I] AdV 3A zu INSPIRE Administrative Units (Variante Gebiete)</name>
     <author>Simon Templer</author>
     <description>Alignment vom 3A-Modell zum INSPIRE Anwendungsschema Administrative Units.
@@ -11,7 +11,7 @@ Zur Bildung der Referenzen zwischen den unterschiedlichen Ebenen von Administrat
 Diese Art der Aggregation mach es nötig, dass für eine konsistente Referenzierung jeweils alle Objekte die zu einer gemeinsamen "upperLevelUnit" gehören auch in der Transformation verfügbar sind -- andernfalls sind die Referenzen unvollständig (z.B. ein Kreis würde ggf. nicht alle seine Gemeinden als "lowerLevelUnit" auflisten).
 Ausnahme bildet hier der Nationalstaat. Referenzen zu/von Nationalstaat werden aktuell nicht erzeugt, da davon ausgegangen wird dass dieser ggf. auf andere Weise gebildet wird und die Vorgehensweise geklärt werden muss.</description>
     <created>2015-09-28T11:46:45.435+02:00</created>
-    <modified>2018-11-02T17:28:50.166+01:00</modified>
+    <modified>2021-08-25T10:50:19.320+02:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>

--- a/annex-1/mappings6.0/AdministrativeUnits/aaa-au-gebiete.halex.alignment.xml
+++ b/annex-1/mappings6.0/AdministrativeUnits/aaa-au-gebiete.halex.alignment.xml
@@ -381,9 +381,9 @@ _target{
 		MultiSurface( geoms[0] )
 	}
 	// Verweis auf Gemeinden
-	gemeinden.each {
+	gemeinden.each { gem -&gt;
 		lowerLevelUnit {
-			href( "#AdministrativeUnit_$it" )
+			href( "#AdministrativeUnit_$gem" )
 		}
 	}
 	_b.upperLevelUnit {

--- a/annex-1/mappings6.0/AdministrativeUnits/aaa-au-kommunalesGebiet.halex.alignment.xml
+++ b/annex-1/mappings6.0/AdministrativeUnits/aaa-au-kommunalesGebiet.halex.alignment.xml
@@ -545,9 +545,9 @@ _target{
 		MultiSurface( union )
 	}
 	// Verweis auf Gemeinden
-	gemeinden.each {
+	gemeinden.each { gem -&gt;
 		lowerLevelUnit {
-			href( "#AdministrativeUnit_$it" )
+			href( "#AdministrativeUnit_$gem" )
 		}
 	}
 	_b.upperLevelUnit {


### PR DESCRIPTION
With the previous implementation, all `au:lowerLevelUnit` elements for 5th order administrative units ("Verwaltungsgemeinschaften") looked like

```
<au:lowerLevelUnit xlink:href="#AdministrativeUnit_null"/>
```

Also ~reverts~ removes references to test source data that is not available in the `testdaten/` directory.