### PR TITLE
base-functions: add logs to identify element without Lagebezeichnung

### DIFF
--- a/annex-1/mappings6.0/base-functions.halex.alignment.xml
+++ b/annex-1/mappings6.0/base-functions.halex.alignment.xml
@@ -127,7 +127,7 @@ if (!name) {
 			if (collect.lagebezeichnung[schluesselGesamt].value()){
 				name = collect.lagebezeichnung[schluesselGesamt].value()
 			}
-			else _log.error('Für einen Namen aus einer verschlüsselten Lagebezeichnung liegt kein Katalogeintrag vor.')
+			else _log.error('Für einen Namen aus einer verschlüsselten Lagebezeichnung mit Schlüssel ${schluesselGesamt} liegt kein Katalogeintrag vor.')
 		}
 	}
 }


### PR DESCRIPTION
For many of the transformations, the error message "Für einen Namen aus einer verschlüsselten Lagebezeichnung liegt kein Katalogeintrag vor." is logged. As it is hard to analyze for which objects these error messages are occurring, the error message should be more detailed.