### PR TITLE
Katalogeintrag handling

### DIFF
--- a/annex-1/mappings6.0/AirTransportNetwork/aaa-tn-a-01.halex
+++ b/annex-1/mappings6.0/AirTransportNetwork/aaa-tn-a-01.halex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="3.5.0.SNAPSHOT">
+<hale-project version="4.2.0.SNAPSHOT">
     <name>[Annex I] AdV 3A zu INSPIRE Air Transport Network</name>
     <author>Simon Templer</author>
     <description>### Alignment von 3A zum INSPIRE Air Transport Network GML Anwendungsschema.
@@ -24,17 +24,17 @@ Im Projekt gibt es zwei verschiedene Herangehensweisen zur Bildung von *Transpor
 1. Ein *TransportProperty*-Objekt für alle Features die auf die gleichen Werte abgebildet werden. Die Identifier werden dabei basierend auf dem Wert oder den Werten welche die jeweilige *TransportProperty* ausmachen gebildet. Umgesetzt wurde das so für `ConditionOfAirFacility`, `SurfaceComposition`, `AerodromeCategory`, `AerodromeType`, und `UseRestriction`.
 2. Ein *TransportProperty*-Objekt für jedes (Quell-)Feature dass über entsprechende Eigenschaften verfügt. Dabei gibt es ggf. sehr viele redundante Informationen in den Objekten. Umgesetzt wurde das so für `ElementWidth`.</description>
     <created>2015-09-28T11:46:45.435+02:00</created>
-    <modified>2018-10-12T10:01:58.312+02:00</modified>
+    <modified>2022-02-21T17:09:05.354+01:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.project.hale25.xml</setting>
-        <setting name="target">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/annex-1/mappings6.0/AirTransportNetwork/aaa-tn-a-01.halex</setting>
+        <setting name="target">file:/C:/Users/Johanna%20Ott/git/adv-inspire-alignments/annex-1/mappings6.0/AirTransportNetwork/aaa-tn-a-01.halex</setting>
     </save-config>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.source" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
         <setting name="charset">UTF-8</setting>
         <setting name="resourceId">fe9e4898-e2ab-4559-bec6-c92a9e455eef</setting>
-        <setting name="source">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
+        <setting name="source">file:/C:/Users/Johanna%20Ott/git/adv-inspire-alignments/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.xsd</setting>
     </resource>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.target" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
@@ -43,15 +43,6 @@ Im Projekt gibt es zwei verschiedene Herangehensweisen zur Bildung von *Transpor
         <setting name="resourceId">55b1c0a5-367a-4ab1-a123-99ed0df1a501</setting>
         <setting name="source">https://inspire.ec.europa.eu/schemas/tn-a/4.0/AirTransportNetwork.xsd</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.xsd</setting>
-    </resource>
-    <resource action-id="eu.esdihumboldt.hale.io.instance.read.source" provider-id="eu.esdihumboldt.hale.io.xml.reader">
-        <setting name="charset">UTF-8</setting>
-        <setting name="resourceId">6a2f5f63-3eb0-445f-9687-08220f2a3e27</setting>
-        <setting name="source">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/testdaten/Hamburg/ATKIS/ATKIS_HH_0011.xml.gz</setting>
-        <setting name="strict">false</setting>
-        <setting name="contentType">eu.esdihumboldt.hale.io.xml.gzip</setting>
-        <setting name="ignoreNamespaces">false</setting>
-        <setting name="ignoreRoot">true</setting>
     </resource>
     <resource action-id="eu.esdihumboldt.hale.codelist.read" provider-id="eu.esdihumboldt.hale.io.codelist.inspire.reader">
         <setting name="charset">UTF-8</setting>
@@ -1636,7 +1627,8 @@ Im Projekt gibt es zwei verschiedene Herangehensweisen zur Bildung von *Transpor
     <property name="mappableSourceType/2">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_FlugverkehrsanlageType</property>
     <property name="mappableSourceType/3">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BauwerkImVerkehrsbereichType</property>
     <property name="mappableSourceType/4">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BauwerkImGewaesserbereichType</property>
-    <property name="mappableSourceType/count">4</property>
+    <property name="mappableSourceType/5">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_LagebezeichnungKatalogeintragType</property>
+    <property name="mappableSourceType/count">5</property>
     <property name="mappableTargetType/1">{http://inspire.ec.europa.eu/schemas/tn/4.0}TransportNetworkType</property>
     <property name="mappableTargetType/10">{http://inspire.ec.europa.eu/schemas/tn-ra/4.0}RailwayElectrificationType</property>
     <property name="mappableTargetType/11">{http://inspire.ec.europa.eu/schemas/tn-ra/4.0}NominalTrackGaugeType</property>
@@ -1684,6 +1676,7 @@ Im Projekt gibt es zwei verschiedene Herangehensweisen zur Bildung von *Transpor
     <property name="mappableTargetType/8">{http://inspire.ec.europa.eu/schemas/tn-ra/4.0}RailwayStationAreaType</property>
     <property name="mappableTargetType/9">{http://inspire.ec.europa.eu/schemas/tn-ra/4.0}RailwayTypeType</property>
     <property name="mappableTargetType/count">46</property>
+    <property name="resource-0619cfa5-eeba-4fa8-804b-324959098694:defaultCRS:{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BauwerkImGewaesserbereichType/{http://www.adv-online.de/namespaces/adv/gid/6.0}position/{http://www.opengis.net/gml/3.2}Surface/{http://www.opengis.net/gml/3.2}patches/{http://www.opengis.net/gml/3.2}PolygonPatch/{http://www.opengis.net/gml/3.2}exterior/{http://www.opengis.net/gml/3.2}Ring/{http://www.opengis.net/gml/3.2}curveMember/{http://www.opengis.net/gml/3.2}Curve/{http://www.opengis.net/gml/3.2}segments/{http://www.opengis.net/gml/3.2}LineStringSegment">code:EPSG:4258</property>
     <property name="resource-0b55205f-6c0e-453c-b938-f369580faaaa:defaultCRS:{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_PunktortAUType/{http://www.adv-online.de/namespaces/adv/gid/6.0}position/{http://www.opengis.net/gml/3.2}Point">code:EPSG:31466</property>
     <property name="resource-0f492db6-9eda-4489-b9df-186a7c82e577:defaultCRS:{http://www.adv-online.de/namespaces/adv/gid/6.0}AP_PPOType/{http://www.adv-online.de/namespaces/adv/gid/6.0}position/{http://www.opengis.net/gml/3.2}MultiPoint/{http://www.opengis.net/gml/3.2}pointMember/{http://www.opengis.net/gml/3.2}Point">code:EPSG:31466</property>
     <property name="resource-0f492db6-9eda-4489-b9df-186a7c82e577:defaultCRS:{http://www.adv-online.de/namespaces/adv/gid/6.0}AP_PTOType/{http://www.adv-online.de/namespaces/adv/gid/6.0}position/{http://www.opengis.net/gml/3.2}Point">code:EPSG:31466</property>

--- a/annex-1/mappings6.0/AirTransportNetwork/aaa-tn-a-01.halex.alignment.xml
+++ b/annex-1/mappings6.0/AirTransportNetwork/aaa-tn-a-01.halex.alignment.xml
@@ -2,6 +2,32 @@
 <alignment xmlns="http://www.esdi-humboldt.eu/hale/alignment">
     <base prefix="ba1" location="../base-tn.halex.alignment.xml"/>
     <base prefix="ba2" location="../base-functions.halex.alignment.xml"/>
+    <cell relation="eu.esdihumboldt.cst.functions.groovy.retype" id="C558a31e8-53bb-4a3e-9b24-bf4fd7211c13" priority="highest">
+        <source>
+            <class>
+                <type name="AX_LagebezeichnungKatalogeintragType" ns="http://www.adv-online.de/namespaces/adv/gid/6.0"/>
+            </class>
+        </source>
+        <target>
+            <class>
+                <type name="AbstractFeatureType" ns="http://www.opengis.net/gml/3.2"/>
+            </class>
+        </target>
+        <complexParameter name="script">
+            <core:text xmlns:core="http://www.esdi-humboldt.eu/hale/core" xml:space="preserve">
+def name = _source.p.bezeichnung.value()&#xD;
+def schluessel = _source.p.schluesselGesamt.value()&#xD;
+&#xD;
+withTransformationContext {&#xD;
+  def collect = _.context.collector(it)&#xD;
+  &#xD;
+  // Name zu Schlüssel der Lagebezeichnung im Index ablegen&#xD;
+  collect.lagebezeichnung[schluessel] = name&#xD;
+}&#xD;
+
+</core:text>
+        </complexParameter>
+    </cell>
     <cell relation="eu.esdihumboldt.cst.functions.groovy.retype" id="Cd2d3c726-c951-484a-8bb0-c17504676eeb" priority="normal">
         <source>
             <class>

--- a/annex-1/mappings6.0/RailroadTransportNetwork/aaa-tn-ra-01.halex
+++ b/annex-1/mappings6.0/RailroadTransportNetwork/aaa-tn-ra-01.halex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="3.5.0.SNAPSHOT">
+<hale-project version="4.2.0.SNAPSHOT">
     <name>[Annex I] AdV 3A zu INSPIRE Railway Transport Network</name>
     <author>Simon Templer</author>
     <description>### Alignment von 3A zum INSPIRE Railway Transport Network GML Anwendungsschema.
@@ -22,17 +22,17 @@ Dieses Verhalten ließe sich auch mit wenigen Änderungen anpassen, so dass für
 
 Im Alignment wird ein *TransportProperty*-Objekt erstellt zusammenfassend für alle Features die auf die gleichen Werte abgebildet werden (z.B. gleicher Zustand für `ConditionOfFacility`). Die Identifier werden dabei basierend auf dem Wert oder den Werten welche die jeweilige *TransportProperty* ausmachen gebildet.</description>
     <created>2015-09-28T11:46:45.435+02:00</created>
-    <modified>2018-10-12T11:52:30.572+02:00</modified>
+    <modified>2022-02-21T17:13:09.499+01:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.project.hale25.xml</setting>
-        <setting name="target">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/annex-1/mappings6.0/RailroadTransportNetwork/aaa-tn-ra-01.halex</setting>
+        <setting name="target">file:/C:/Users/Johanna%20Ott/git/adv-inspire-alignments/annex-1/mappings6.0/RailroadTransportNetwork/aaa-tn-ra-01.halex</setting>
     </save-config>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.source" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
         <setting name="charset">UTF-8</setting>
         <setting name="resourceId">fe9e4898-e2ab-4559-bec6-c92a9e455eef</setting>
-        <setting name="source">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
+        <setting name="source">file:/C:/Users/Johanna%20Ott/git/adv-inspire-alignments/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.xsd</setting>
     </resource>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.target" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
@@ -1366,14 +1366,13 @@ Im Alignment wird ein *TransportProperty*-Objekt erstellt zusammenfassend für a
     <property name="instances.sampling.sampler">first</property>
     <property name="instances.sampling.settings.first">1</property>
     <property name="instances.sampling.settings.skip">10</property>
-    <property name="mappableSourceType/1">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_LagebezeichnungKatalogeintragType</property>
-    <property name="mappableSourceType/2">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BahnstreckeType</property>
-    <property name="mappableSourceType/3">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_SeilbahnSchwebebahnType</property>
-    <property name="mappableSourceType/4">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BahnverkehrType</property>
-    <property name="mappableSourceType/5">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BahnverkehrsanlageType</property>
-    <property name="mappableSourceType/6">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BauwerkImVerkehrsbereichType</property>
-    <property name="mappableSourceType/7">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BauwerkImGewaesserbereichType</property>
-    <property name="mappableSourceType/count">7</property>
+    <property name="mappableSourceType/1">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BahnstreckeType</property>
+    <property name="mappableSourceType/2">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_SeilbahnSchwebebahnType</property>
+    <property name="mappableSourceType/3">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BahnverkehrType</property>
+    <property name="mappableSourceType/4">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BahnverkehrsanlageType</property>
+    <property name="mappableSourceType/5">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BauwerkImVerkehrsbereichType</property>
+    <property name="mappableSourceType/6">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BauwerkImGewaesserbereichType</property>
+    <property name="mappableSourceType/count">6</property>
     <property name="mappableTargetType/1">{http://inspire.ec.europa.eu/schemas/tn/4.0}TransportNetworkType</property>
     <property name="mappableTargetType/10">{http://inspire.ec.europa.eu/schemas/tn-ra/4.0}RailwayElectrificationType</property>
     <property name="mappableTargetType/11">{http://inspire.ec.europa.eu/schemas/tn-ra/4.0}NominalTrackGaugeType</property>

--- a/annex-1/mappings6.0/base-tn.halex
+++ b/annex-1/mappings6.0/base-tn.halex
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="3.5.0.SNAPSHOT">
+<hale-project version="4.2.0.SNAPSHOT">
     <name>AdV Basis-Alignment 3A zu INSPIRE Transport Networks</name>
     <author>Simon Templer</author>
     <description>Basisprojekt für gemeinsame Funktionalität für INSPIRE Transport Networks Projekte.</description>
     <created>2015-09-28T11:46:45.435+02:00</created>
-    <modified>2018-10-12T09:48:22.920+02:00</modified>
+    <modified>2022-02-21T17:23:04.061+01:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.project.hale25.xml</setting>
-        <setting name="target">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/annex-1/mappings6.0/base-tn.halex</setting>
+        <setting name="target">file:/C:/Users/Johanna%20Ott/git/adv-inspire-alignments/annex-1/mappings6.0/base-tn.halex</setting>
     </save-config>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.source" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
         <setting name="charset">UTF-8</setting>
         <setting name="resourceId">fe9e4898-e2ab-4559-bec6-c92a9e455eef</setting>
-        <setting name="source">file:/C:/Users/Johanna%20Ott/eclipse/workspace/gits/adv-inspire-alignments/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
+        <setting name="source">file:/C:/Users/Johanna%20Ott/git/adv-inspire-alignments/schemas/NAS_6.0.1/schema/aaa.xsd</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.xsd</setting>
     </resource>
     <resource action-id="eu.esdihumboldt.hale.io.schema.read.target" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
@@ -1252,9 +1252,8 @@
     <property name="instances.sampling.settings.first">1</property>
     <property name="instances.sampling.settings.skip">10</property>
     <property name="mappableSourceType/1">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_WegPfadSteigType</property>
-    <property name="mappableSourceType/10">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_LagebezeichnungKatalogeintragType</property>
-    <property name="mappableSourceType/11">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BauwerkImVerkehrsbereichType</property>
-    <property name="mappableSourceType/12">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BauwerkImGewaesserbereichType</property>
+    <property name="mappableSourceType/10">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BauwerkImVerkehrsbereichType</property>
+    <property name="mappableSourceType/11">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_BauwerkImGewaesserbereichType</property>
     <property name="mappableSourceType/2">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_PlatzType</property>
     <property name="mappableSourceType/3">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_KlassifizierungNachStrassenrechtType</property>
     <property name="mappableSourceType/4">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_StrassenverkehrType</property>
@@ -1263,7 +1262,7 @@
     <property name="mappableSourceType/7">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_StrasseType</property>
     <property name="mappableSourceType/8">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_FahrbahnachseType</property>
     <property name="mappableSourceType/9">{http://www.adv-online.de/namespaces/adv/gid/6.0}AX_StrassenachseType</property>
-    <property name="mappableSourceType/count">12</property>
+    <property name="mappableSourceType/count">11</property>
     <property name="mappableTargetType/1">{http://inspire.ec.europa.eu/schemas/tn/4.0}TransportNetworkType</property>
     <property name="mappableTargetType/2">{http://inspire.ec.europa.eu/schemas/net/4.0}NetworkElementType</property>
     <property name="mappableTargetType/3">{http://inspire.ec.europa.eu/schemas/tn/4.0}ConditionOfFacilityType</property>

--- a/annex-1/mappings6.0/base-tn.halex.alignment.xml
+++ b/annex-1/mappings6.0/base-tn.halex.alignment.xml
@@ -55,31 +55,6 @@ withTransformationContext {
         <documentation>Dies ist eine Dummy-Transformationsdefinition die keine Objekte erzeugt sondern zum Aufbauen eines Index für die Bauwerksfunktion von `AX_BauwerkImVerkehrsbereich` dient.
 Diese Information wird herangezogen um entsprechend für REO-Objekte über die Beziehung `hatDirektUnten` den entsprechenden Wert für die *TransportProperty* `VerticalPosition` zu bestimmen.</documentation>
     </cell>
-    <cell relation="eu.esdihumboldt.cst.functions.groovy.retype" id="Cf14d9443-cd2c-4184-a791-a8bc488cdd5e" priority="highest">
-        <source>
-            <class>
-                <type name="AX_LagebezeichnungKatalogeintragType" ns="http://www.adv-online.de/namespaces/adv/gid/6.0"/>
-            </class>
-        </source>
-        <target>
-            <class>
-                <type name="AbstractFeatureType" ns="http://www.opengis.net/gml/3.2"/>
-            </class>
-        </target>
-        <complexParameter name="script">
-            <core:text xmlns:core="http://www.esdi-humboldt.eu/hale/core" xml:space="preserve">
-def name = _source.p.bezeichnung.value()&#xD;
-def schluessel = _source.p.schluesselGesamt.value()&#xD;
-&#xD;
-withTransformationContext {&#xD;
-  def collect = _.context.collector(it)&#xD;
-  &#xD;
-  // Name zu Schlüssel der Lagebezeichnung im Index ablegen&#xD;
-  collect.lagebezeichnung[schluessel] = name&#xD;
-}
-</core:text>
-        </complexParameter>
-    </cell>
     <cell relation="eu.esdihumboldt.cst.functions.groovy.create" id="C1eb2d011-34d1-4077-8388-f7fbdb1659b9" priority="low">
         <target>
             <class>


### PR DESCRIPTION
There was a misinterpretation on the handling of AX_LagebezeichnungKatalogeintrag. It is not needed in all TN alignments and was already available in the TN-RO alignment.
In order to keep the alignments consistence, the handling was removed from the tn-base alignment and added to the tn-a alignment where it was needed.