### PR TITLE
fix(tn-w): fix ConditionOfWaterFacility associations

### DIFF
--- a/annex-1/mappings6.0/WaterTransportNetwork/aaa-tn-w-01.halex
+++ b/annex-1/mappings6.0/WaterTransportNetwork/aaa-tn-w-01.halex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="4.0.0.SNAPSHOT">
+<hale-project version="4.2.0.SNAPSHOT">
     <name>[Annex I] AdV 3A zu INSPIRE Water Transport Network</name>
     <author>Simon Templer</author>
     <description>### Alignment von 3A zum INSPIRE Water Transport Network GML Anwendungsschema.
@@ -22,7 +22,7 @@ Dieses Verhalten ließe sich auch mit wenigen Änderungen anpassen, so dass für
 Ein *TransportProperty*-Objekt wird erstellt für alle Features die über die gleichen Eigenschaften bzgl. der *TransportProperty* verfügen. Die Identifier werden dabei basierend auf dem Wert oder den Werten welche die jeweilige *TransportProperty* ausmachen gebildet. Umgesetzt wurde das so für `ConditionOfWaterFacility`, `FerryUse` und `VerticalPosition`.
 </description>
     <created>2015-09-28T11:46:45.435+02:00</created>
-    <modified>2019-09-09T09:46:32.096+02:00</modified>
+    <modified>2022-07-19T16:54:27.737+02:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>

--- a/annex-1/mappings6.0/WaterTransportNetwork/aaa-tn-w-01.halex.alignment.xml
+++ b/annex-1/mappings6.0/WaterTransportNetwork/aaa-tn-w-01.halex.alignment.xml
@@ -1512,11 +1512,24 @@ def _id = "PortArea_$sourceId"
 _target {
 }
 
+// bestimme ConditionOfWaterFacility
+def conditionOfFacility = 'functional'
+switch (_source.p.zustand.value()) {
+	case '2100': // Außer Betrieb, stillgelegt, verlassen
+		conditionOfFacility = 'disused'
+		break
+	case '4000': // Im Bau
+		conditionOfFacility = 'underConstruction'
+		break
+}
+
 def collect
 withTransformationContext {
 	collect = _.context.collector(it)
 	// Sammle ID für Netzwerk	
 	collect.network &lt;&lt; _id
+	// Sammle ID für ConditionOfWaterFacility
+	collect.conditionOfWaterFacility[conditionOfFacility] &lt;&lt; _id
 }
 
 /*
@@ -1820,7 +1833,7 @@ if (parentId) {
 	_target {
 	}
 	
-	// bestimme ConditionOfWaterFacility
+	// bestimme ConditionOfFacility
 	def conditionOfFacility = 'functional'
 	switch (_source.p.zustand.value()) {
 	case '2100': // Außer Betrieb, stillgelegt, verlassen
@@ -1830,7 +1843,7 @@ if (parentId) {
 		conditionOfFacility = 'underConstruction'
 		break
 	}
-	
+
 	def collect
 	withTransformationContext {
 		collect = _.context.collector(it)
@@ -1839,7 +1852,7 @@ if (parentId) {
 		// Sammle ID für Liste von WaterwayLinks für den Kanal
 		collect.AX_Kanal[parentId].links &lt;&lt; _id
 		// Sammle ID für ConditionOfWaterFacility
-		collect.conditionOfWaterFacility[conditionOfFacility] &lt;&lt; _id
+		collect.conditionOfFacility[conditionOfFacility] &lt;&lt; _id
 	}
 	
 	/*
@@ -2761,7 +2774,4 @@ Für alle anderen `bauwerksfunktion`en, Referenzen auf andere Objekte oder auch 
         </target>
         <parameter value="other:unpopulated" name="value"/>
     </cell>
-    <modifier cell="ba1:C1eb2d011-34d1-4077-8388-f7fbdb1659b9">
-        <transformation mode="disabled"/>
-    </modifier>
 </alignment>


### PR DESCRIPTION
Replaces the association of `ConditionOfWaterFacility` objects to
`WaterwayLink` objects with associations to `ConditionOfFacility`
objects because an association to `ConditionOfWaterFacility` is not
allowed by the INSPIRE data model (see sec. 5.7.2.1.4. of the Data
Specification on Transport Networks - Technical Guidelines).

Also, an association of `PortArea` objects to `ConditionOfWaterFacility`
is added for which such an association is allowed.

SVC-1192