### PR TITLE
refactor(au): support multiple AX_KommunalesGebiet per AX_Gemeinde

### DIFF
--- a/annex-1/mappings6.0/AdministrativeUnits/aaa-au-gebiete.halex.alignment.xml
+++ b/annex-1/mappings6.0/AdministrativeUnits/aaa-au-gebiete.halex.alignment.xml
@@ -527,7 +527,7 @@ if (!upperLevelUnit) {
 
 _target{
 	geometry {
-		MultiSurface( geoms[0] )
+		MultiSurface( _.geom.aggregate(geoms) )
 	}
 	_b.upperLevelUnit {
 		href( "#${upperLevelUnit}" )


### PR DESCRIPTION
Allow for multiple `AX_KommunalesGebiet` instances to exist that have the same `gemeindekennzeichen`. With this patch, the geometries of these `AX_KommunalesGebiet` instances will be aggregated instead of only one being selected randomly.

SVC-890