### PR TITLE
refactor: update base alignment used

### DIFF
--- a/annex-1/mappings7.1/AdministrativeUnits/aaa-au-basis.halex.alignment.xml
+++ b/annex-1/mappings7.1/AdministrativeUnits/aaa-au-basis.halex.alignment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <alignment xmlns="http://www.esdi-humboldt.eu/hale/alignment">
-    <base prefix="ba1" location="../../mappings6.0/base-functions.halex.alignment.xml"/>
+    <base prefix="ba1" location="../base-functions.halex.alignment.xml"/>
     <cell relation="eu.esdihumboldt.hale.align.retype" id="C69d2dcb1-a278-425f-9b2e-b282471adc4c" priority="normal">
         <source>
             <class>


### PR DESCRIPTION
use version 7.1 instead of 6.0

Has been forgotton in [this earlier PR](https://github.com/wetransform/adv-inspire-alignments/pull/70).

SVC-1464