### PR TITLE
fix: use AdV specific name mapping

### DIFF
--- a/annex-2-3/mappings6.0/Buildings/2D/3A2INSPIRE_BU2D.halex
+++ b/annex-2-3/mappings6.0/Buildings/2D/3A2INSPIRE_BU2D.halex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="4.0.0.SNAPSHOT">
+<hale-project version="5.1.0.SNAPSHOT">
     <name>[Annex III] AdV 3A zu INSPIRE Building 2D</name>
     <author>Johanna Ott</author>
     <description>Hinweis zur Nutzung der Projektvariablen:&#xD;
@@ -9,7 +9,7 @@
     HORIZONTALGEOMETRYREFERENCEVALUE_BEFLIEGUNGSGEBAEUDE: default ist "footprint", falls anderer Wert aus der Codeliste (http://inspire.ec.europa.eu/codelist/HorizontalGeometryReferenceValue) erwünscht --&gt; angeben&#xD;
     INSPIRE_NAMESPACE: gewünschten Namespace eingeben</description>
     <created>2018-04-10T10:51:13.547+02:00</created>
-    <modified>2020-09-15T11:37:36.107+02:00</modified>
+    <modified>2023-05-16T14:51:54.280+02:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>

--- a/annex-2-3/mappings6.0/Buildings/2D/3A2INSPIRE_BU2D.halex.alignment.xml
+++ b/annex-2-3/mappings6.0/Buildings/2D/3A2INSPIRE_BU2D.halex.alignment.xml
@@ -105,8 +105,8 @@
         </target>
         <parameter value="{{project:INSPIRE_NAMESPACE}}" name="value"/>
     </cell>
-    <cell relation="eu.esdihumboldt.hale.align.rename" id="C041711db-6015-40e6-9198-513e210b5ef7" priority="normal">
-        <source>
+    <cell relation="custom:alignment:adv.inspire.GeographicalName.simple" id="C041711db-6015-40e6-9198-513e210b5ef7" priority="normal">
+        <source name="spelling">
             <property>
                 <type name="AA_ObjektType" ns="http://www.adv-online.de/namespaces/adv/gid/6.0"/>
                 <child name="name" ns="http://www.opengis.net/gml/3.2"/>
@@ -117,13 +117,8 @@
                 <type name="AbstractBuildingType" ns="http://inspire.ec.europa.eu/schemas/bu-base/4.0"/>
                 <child name="name" ns="http://inspire.ec.europa.eu/schemas/bu-base/4.0"/>
                 <child name="GeographicalName" ns="http://inspire.ec.europa.eu/schemas/gn/4.0"/>
-                <child name="spelling" ns="http://inspire.ec.europa.eu/schemas/gn/4.0"/>
-                <child name="SpellingOfName" ns="http://inspire.ec.europa.eu/schemas/gn/4.0"/>
-                <child name="text" ns="http://inspire.ec.europa.eu/schemas/gn/4.0"/>
             </property>
         </target>
-        <parameter value="false" name="ignoreNamespaces"/>
-        <parameter value="false" name="structuralRename"/>
         <documentation>wird auf Ebene von AA_Objekt durchgeführt, weil alle FeatureTypen davon erben und Abbildung für alle gültig.</documentation>
     </cell>
     <cell relation="eu.esdihumboldt.cst.functions.groovy.retype" id="C7a92c0b5-e161-4208-a6c5-ac722aeb297c" priority="normal">


### PR DESCRIPTION
Only the text element of GeographicalName was mapped. Instead, all elements possible should be filled.
The mapping is therefore changed so that the AdV specific function is used.

Detected in the context of SVC-1467