### PR TITLE
feat: provide link to upperLevel AdministrativeUnits

### DIFF
--- a/annex-1/mappings/AdministrativeUnits/aaa-au-flurstuecke.halex
+++ b/annex-1/mappings/AdministrativeUnits/aaa-au-flurstuecke.halex
@@ -15,7 +15,7 @@ Das gleiche gilt für die aggregierten Geometrien -- hier werden bei unvollstän
 &#13;
 Sofern möglich sollte alternativ für die Transformation das Projekt mit Aggregierung aus `AX_KommunalesGebiet` verwendet werden. Falls diese Objekte nich vorhanden sind, könnten als Zwischenschritt auch `AX_KommunalesGebiet` aus Flurstücken abgeleitet werden.</description>
     <created>2015-09-28T11:46:45.435+02:00</created>
-    <modified>2023-03-16T11:02:24.651+01:00</modified>
+    <modified>2023-08-30T09:49:57.396+02:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>

--- a/annex-1/mappings/AdministrativeUnits/aaa-au-flurstuecke.halex.alignment.xml
+++ b/annex-1/mappings/AdministrativeUnits/aaa-au-flurstuecke.halex.alignment.xml
@@ -835,6 +835,22 @@ Die Verknüpfung zur untergeordneten Ebene von `AdministrativeUnit`s wird über 
 
 Die Information über die Zugehörigkeit zur übergeordneten `AdministrativeUnit` (Bundesland) und die Geometrie werden im Index hinterlegt.</documentation>
     </cell>
+    <cell relation="eu.esdihumboldt.hale.align.assign.bound" id="C8dac57f2-ccc4-4666-997a-6900aedfd82a" priority="normal">
+        <source name="anchor">
+            <property>
+                <type name="AX_BundeslandType" ns="http://www.adv-online.de/namespaces/adv/gid/7.1"/>
+                <child name="id" ns="http://www.opengis.net/gml/3.2"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AdministrativeUnitType" ns="http://inspire.ec.europa.eu/schemas/au/4.0"/>
+                <child name="upperLevelUnit" ns="http://inspire.ec.europa.eu/schemas/au/4.0"/>
+                <child name="href" ns="http://www.w3.org/1999/xlink"/>
+            </property>
+        </target>
+        <parameter value="https://sgx.geodatenzentrum.de/wfs_dlm250_inspire?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=GetFeature&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.2.1&amp;STOREDQUERY_ID=urn:ogc:def:query:OGC-WFS::GetFeatureById&amp;ID=DLM250_AdministrativeUnit_000000000000#DLM250_AdministrativeUnit_000000000000" name="value"/>
+    </cell>
     <modifier cell="ba1:C121e3917-16e0-4cba-87db-8a21b67b8c60">
         <disable-for parent="C153144ee-8008-471c-a689-adba7e1d10b7"/>
     </modifier>

--- a/annex-1/mappings/AdministrativeUnits/aaa-au-gebiete.halex
+++ b/annex-1/mappings/AdministrativeUnits/aaa-au-gebiete.halex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="5.1.0.SNAPSHOT">
+<hale-project version="5.2.0.SNAPSHOT">
     <name>[Annex I] AdV 3A 7.1.2 zu INSPIRE Administrative Units (Variante Gebiete)</name>
     <author>Simon Templer</author>
     <description>Alignment vom 3A-Modell zum INSPIRE Anwendungsschema Administrative Units.&#13;
@@ -11,7 +11,7 @@ Zur Bildung der Referenzen zwischen den unterschiedlichen Ebenen von Administrat
 Diese Art der Aggregation mach es nötig, dass für eine konsistente Referenzierung jeweils alle Objekte die zu einer gemeinsamen "upperLevelUnit" gehören auch in der Transformation verfügbar sind -- andernfalls sind die Referenzen unvollständig (z.B. ein Kreis würde ggf. nicht alle seine Gemeinden als "lowerLevelUnit" auflisten).&#13;
 Ausnahme bildet hier der Nationalstaat. Referenzen zu/von Nationalstaat werden aktuell nicht erzeugt, da davon ausgegangen wird dass dieser ggf. auf andere Weise gebildet wird und die Vorgehensweise geklärt werden muss.</description>
     <created>2015-09-28T11:46:45.435+02:00</created>
-    <modified>2023-04-06T15:36:33.708+02:00</modified>
+    <modified>2024-04-29T10:18:09.416+02:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>

--- a/annex-1/mappings/AdministrativeUnits/aaa-au-gebiete.halex.alignment.xml
+++ b/annex-1/mappings/AdministrativeUnits/aaa-au-gebiete.halex.alignment.xml
@@ -541,4 +541,23 @@ Die Geometrie wird aus dem über den Gesamtschlüssel verknüpften `AX_Kommunale
 Über den Index wird bestimmt ob die Gemeinde zu einer Verwaltungsgemeinschaft gehört. Diese wird als `upperLevelUnit` referenziert.
 Falls keine Zugehörigkeit zu einer Verwaltungsgemeinschaft besteht wird die Zugehörigkeit zur übergeordneten `AdministrativeUnit` (in diesem Fall *Kreis*) im Index hinterlegt.</documentation>
     </cell>
+    <cell relation="eu.esdihumboldt.hale.align.assign.bound" id="Cf87a0aaa-4569-4c8f-82ef-7f9760a3c186" priority="normal">
+        <source name="anchor">
+            <property>
+                <type name="AX_BundeslandType" ns="http://www.adv-online.de/namespaces/adv/gid/7.1"/>
+                <child name="schluesselGesamt" ns="http://www.adv-online.de/namespaces/adv/gid/7.1"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AdministrativeUnitType" ns="http://inspire.ec.europa.eu/schemas/au/4.0"/>
+                <child name="upperLevelUnit" ns="http://inspire.ec.europa.eu/schemas/au/4.0"/>
+                <child name="href" ns="http://www.w3.org/1999/xlink"/>
+            </property>
+        </target>
+        <parameter value="https://sgx.geodatenzentrum.de/wfs_dlm250_inspire?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=GetFeature&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.2.1&amp;STOREDQUERY_ID=urn:ogc:def:query:OGC-WFS::GetFeatureById&amp;ID=DLM250_AdministrativeUnit_000000000000#DLM250_AdministrativeUnit_000000000000" name="value"/>
+    </cell>
+    <modifier cell="C1c3a0ce9-5605-4868-a6af-c9acbc1d41f2">
+        <transformation mode="disabled"/>
+    </modifier>
 </alignment>

--- a/annex-1/mappings/AdministrativeUnits/aaa-au-kommunalesGebiet.halex
+++ b/annex-1/mappings/AdministrativeUnits/aaa-au-kommunalesGebiet.halex
@@ -13,7 +13,7 @@ Ausnahme bildet hier der Nationalstaat. Eine `AdministrativeUnit` die den Nation
 &#13;
 Das gleiche gilt für die aggregierten Geometrien -- hier werden bei unvollständigen Eingangsdaten für die Transformation entsprechend unvollständige aggregierte Geometrien erzeugt.</description>
     <created>2015-09-28T11:46:45.435+02:00</created>
-    <modified>2023-04-04T17:15:32.510+02:00</modified>
+    <modified>2023-08-30T09:50:49.568+02:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>

--- a/annex-1/mappings/AdministrativeUnits/aaa-au-kommunalesGebiet.halex.alignment.xml
+++ b/annex-1/mappings/AdministrativeUnits/aaa-au-kommunalesGebiet.halex.alignment.xml
@@ -870,6 +870,22 @@ Die Verknüpfung zur untergeordneten Ebene von `AdministrativeUnit`s wird über 
 
 Die Information über die Zugehörigkeit zur übergeordneten `AdministrativeUnit` (Bundesland) und die Geometrie werden im Index hinterlegt.</documentation>
     </cell>
+    <cell relation="eu.esdihumboldt.hale.align.assign.bound" id="C70fd5994-51dd-4e44-8f6f-84e26866a95d" priority="normal">
+        <source name="anchor">
+            <property>
+                <type name="AX_BundeslandType" ns="http://www.adv-online.de/namespaces/adv/gid/7.1"/>
+                <child name="id" ns="http://www.opengis.net/gml/3.2"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AdministrativeUnitType" ns="http://inspire.ec.europa.eu/schemas/au/4.0"/>
+                <child name="upperLevelUnit" ns="http://inspire.ec.europa.eu/schemas/au/4.0"/>
+                <child name="href" ns="http://www.w3.org/1999/xlink"/>
+            </property>
+        </target>
+        <parameter value="https://sgx.geodatenzentrum.de/wfs_dlm250_inspire?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=GetFeature&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.2.1&amp;STOREDQUERY_ID=urn:ogc:def:query:OGC-WFS::GetFeatureById&amp;ID=DLM250_AdministrativeUnit_000000000000#DLM250_AdministrativeUnit_000000000000" name="value"/>
+    </cell>
     <modifier cell="ba1:C121e3917-16e0-4cba-87db-8a21b67b8c60">
         <disable-for parent="C38c7c833-c314-4e4a-8d7f-d166e120e878"/>
     </modifier>


### PR DESCRIPTION
The link to an AdministrativeUnit representing Germany has been provided in the context of this task
https://haleconnect.com/#/transformation/org/163/d0512d1d-39ab-4f55-980e-ee6f6a4083d9/tasks/a8j6 It is now inlcuded in the respective alignments.
Also, for the Gebiete alignment, the function creating the national AdministrativeUni from AX_Nationalstaat is disabled.

SVC-856