### PR TITLE
Adapt ad-hk Gradle transformation to new source file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,24 +72,21 @@ Alle weiteren *Tasks* stehen für die Transformation eines bestimmten Projekts, 
 
 ### Transformation für Hauskoordinaten
 
-Die Transformation von Hauskoordinaten zu Adressen ist ein Spezialfall, da hier kein XML als Quelle vorhanden ist, sondern CSV-Dateien.
+Die Transformation von Hauskoordinaten zu Adressen ist ein Spezialfall, da hier kein XML als Quelle vorhanden ist, sondern eine CSV-Datei.
 
 Das Kürzel `ad-hk` steht für diese Transformation und wird anders behandelt als die restlichen Transformationen.
-Die Quell-Dateien müssen hier einzeln angegeben werden, als Gradle properties (z.B. in der Datei `gradle.properties`):
+Die Quell-Datei muss hier über folgende Eingenschaft konfiguriert werden (z.B. in der Datei `gradle.properties`):
 
-- **hkSchluesselDatei** - Pfad zur CSV-Datei mit Schlüssel-Informationen
 - **hkDatei** - Pfad zur Datei mit Hauskoordinaten
 
-Sind diese Eigenschaften nicht angegeben, werden standardmäßig Testdaten aus dem Repository verwendet.
+Ist diese Eigenschaft nicht konfiguriert, wird standardmäßig eine Testdatei aus dem Repository verwendet.
 
-Zusätzlich muss für jede der beiden Dateien angegeben werden, ob die erste Zeile der Datei übersprungen werden soll. Dies geschieht ebenfalls über Gradle properties. Eine Konfiguration kann beispielsweise so aussehen:
+Zusätzlich muss für die Datei angegeben werden, wie viele Zeilen beim Einlesen übersprungen werden sollen. Dies geschieht ebenfalls über die Datei `gradle.properties`. Wird kein Wert für `hkSkipFirst` konfiguriert, wird standardmäßig davon ausgegangen, dass eine Zeile übersprungen werden muss. Eine Konfiguration kann beispielsweise so aussehen:
 
 ```
-# Hauskoordinaten (CSV-Dateien)
-hkSchluesselDatei=hk/schluessel.csv
-hkSchluesselSkipFirst=false
+# Hauskoordinaten (CSV-Datei)
 hkDatei=hk/adressen.csv
-hkSkipFirst=true
+hkSkipFirst=1
 ```
 
 Weitere Einstellungen zum Lesen der CSV-Dateien (z.B. Trennzeichen) sind im Moment fest konfiguriert.

--- a/build.gradle
+++ b/build.gradle
@@ -442,8 +442,7 @@ transformations.each { name, config ->
       // Hauskoordinaten project
       
       // file locations
-      def hkSchluesselDatei = project.hasProperty('hkSchluesselDatei') ? project.getProperty('hkSchluesselDatei') : project.file('testdaten/Hauskoordinaten/schluessel_test.csv')
-      def hkDatei = project.hasProperty('hkDatei') ? project.property('hkDatei') : project.file('testdaten/Hauskoordinaten/adressen_test.csv')
+      def hkDatei = project.hasProperty('hkDatei') ? project.property('hkDatei') : project.file('testdaten/Hauskoordinaten/5.0/adressen-testdaten.csv')
 
       // common settings
       def hkQuote = '"'
@@ -454,24 +453,11 @@ transformations.each { name, config ->
 
       // define sources
       
-      source(hkSchluesselDatei) {
-        provider 'eu.esdihumboldt.hale.io.csv.reader.instance'
-
-        setting 'typename', 'Schlüssel'
-        setting 'skip', project.hasProperty('hkSchluesselSkipFirst') ? project.getProperty('hkSchluesselSkipFirst') : false
-
-        setting 'charset', hkCharset
-        setting 'quote', hkQuote
-        setting 'decimal', hkDecimal
-        setting 'separator', hkSeparator
-        setting 'escape', hkEscape
-      }
-
       source(hkDatei) {
         provider 'eu.esdihumboldt.hale.io.csv.reader.instance'
 
         setting 'typename', 'Hauskoordinaten'
-        setting 'skip', project.hasProperty('hkSkipFirst') ? project.getProperty('hkSkipFirst') : false
+        setting 'skip', project.hasProperty('hkSkipFirst') ? project.getProperty('hkSkipFirst') : 1
 
         setting 'charset', hkCharset
         setting 'quote', hkQuote

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ plugins {
 apply plugin: 'to.wetransform.hale'
 
 hale {
-  cliVersion = '5.1.0-SNAPSHOT' // for update to hale-connect
+  cliVersion = '5.1.0'
 }
 
 configurations.all {

--- a/gradle.properties.sample
+++ b/gradle.properties.sample
@@ -43,11 +43,9 @@ haleMaxHeapSize=2048
 # Other system properties
 # - Custom temporary directory
 #systemProp.java.io.tmpdir=
-# Hauskoordinaten (CSV-Dateien)
-#hkSchluesselDatei=
-#hkSchluesselSkipFirst=false
+# Hauskoordinaten (CSV-Datei)
 #hkDatei=
-#hkSkipFirst=false
+#hkSkipFirst=1
 # WFS-T upload
 #uploadWFS=http://localhost:8080/services/wfs
 # hale connect


### PR DESCRIPTION
Format version 5.0 of the Hauskoordinaten source file no longer requires a "Schluessel" file, so the correspondig configuration in the Gradle build is removed. The new format has a header line, so the `skipFirst` default is changed accordingly. The `skip` parameter is also changed to a number as the corresponding parameter of the hale»studio CSV reader has changed.

SVC-1463