### PR TITLE
Fix: Clean-up of referenced resources

### DIFF
--- a/annex-2-3/mappings/Buildings/2D/3A2INSPIRE_BU2D.halex
+++ b/annex-2-3/mappings/Buildings/2D/3A2INSPIRE_BU2D.halex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="5.1.0.SNAPSHOT">
+<hale-project version="5.4.0.release">
     <name>[Annex III] AdV 3A zu INSPIRE Building 2D</name>
     <author>Johanna Ott</author>
     <description>Hinweis zur Nutzung der Projektvariablen:&#13;
@@ -9,7 +9,7 @@
     HORIZONTALGEOMETRYREFERENCEVALUE_BEFLIEGUNGSGEBAEUDE: default ist "footprint", falls anderer Wert aus der Codeliste (http://inspire.ec.europa.eu/codelist/HorizontalGeometryReferenceValue) erwünscht --&gt; angeben&#13;
     INSPIRE_NAMESPACE: gewünschten Namespace eingeben</description>
     <created>2018-04-10T10:51:13.547+02:00</created>
-    <modified>2023-07-11T16:32:37.609+02:00</modified>
+    <modified>2025-09-09T17:29:25.362+02:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>

--- a/annex-2-3/mappings/Buildings/2D/3A2INSPIRE_BU2D.halex
+++ b/annex-2-3/mappings/Buildings/2D/3A2INSPIRE_BU2D.halex
@@ -264,21 +264,6 @@
         <setting name="source">http://inspire.ec.europa.eu/codelist/HorizontalGeometryReferenceValue</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.codelist.inspire</setting>
     </resource>
-    <resource action-id="eu.esdihumboldt.hale.io.instance.read.source" provider-id="eu.esdihumboldt.hale.io.xml.reader">
-        <setting name="charset">UTF-8</setting>
-        <setting name="resourceId">12a59ca7-fa6c-43e1-a6fd-b4a33633d954</setting>
-        <setting name="source">file:/C:/Users/Johanna/Box%20Sync/My%20Box%20Notes/AdV/Testdaten/Berlin/Bauteil_ohne_bezug_mitBaujahr.xml</setting>
-        <setting name="interpolation.maxError">0.1</setting>
-        <setting name="interpolation.algorithm">segment</setting>
-        <setting name="ignoreNamespaces">false</setting>
-        <setting name="paginateRequest">true</setting>
-        <setting name="featuresPerWfsRequest">1000</setting>
-        <setting name="ignoreRoot">true</setting>
-        <setting name="ignoreNumberMatched">false</setting>
-        <setting name="interpolation.grid.moveAllToGrid">false</setting>
-        <setting name="strict">false</setting>
-        <setting name="contentType">org.eclipse.core.runtime.xml</setting>
-    </resource>
     <export-config name="hale-connect">
         <configuration action-id="eu.esdihumboldt.hale.io.instance.write.transformed" provider-id="eu.esdihumboldt.hale.io.gml.writer">
             <setting name="charset">UTF-8</setting>

--- a/annex-2-3/mappings/Buildings/2D/3A2INSPIRE_BU2D.halex
+++ b/annex-2-3/mappings/Buildings/2D/3A2INSPIRE_BU2D.halex
@@ -68,7 +68,7 @@
         <setting name="name">AX_Gebaudefunktion_Gebaeude_cu</setting>
         <setting name="valueColumn">2</setting>
         <setting name="skip">true</setting>
-        <setting name="source">Unterlagen/TabellenCurrentUse/AX_Gebaudefunktion_Gebaeude.xlsx</setting>
+        <setting name="source">Unterlagen/TabellenCurrentUse/AX_Gebaeudefunktion_Gebaeude.xlsx</setting>
         <setting name="contentType">eu.esdihumboldt.hale.io.xls.xlsx</setting>
     </resource>
     <resource action-id="eu.esdihumboldt.hale.lookup.import" provider-id="eu.esdihumboldt.hale.io.xls.reader.lookup">


### PR DESCRIPTION
During work on SVC-2169, two mistakes in the 6.0 version of the project were detected that prevented the project file from loading referenced resources correctly: A typo in a file name is fixed, and unnecessary test data removed.
